### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/child-issue.md
+++ b/.github/ISSUE_TEMPLATE/child-issue.md
@@ -1,0 +1,17 @@
+---
+name: Child issue
+about: Child issue
+title: "[Child issue]"
+labels: enhancement
+assignees: manudev-1
+
+---
+
+## Child issue
+General description of the issue
+
+### Linear working process
+- step 1
+- step 2
+    - step 2.1
+- step 3

--- a/.github/ISSUE_TEMPLATE/father-issue--milestone-.md
+++ b/.github/ISSUE_TEMPLATE/father-issue--milestone-.md
@@ -1,0 +1,15 @@
+---
+name: Father issue (Milestone)
+about: Father issue
+title: "[Father issue (Milestones)]"
+labels: enhancement
+assignees: manudev-1
+
+---
+
+# Father issue
+General description
+
+## List of Enhancements
+- #issue father
+    - #issue father


### PR DESCRIPTION
## Summary by Sourcery

Add two new GitHub issue templates under .github/ISSUE_TEMPLATE to standardize child and father (milestone) issue creation

Documentation:
- Add GitHub issue template for child issues
- Add GitHub issue template for father issues (milestone)