### PR TITLE
Add EEGEncoder model and command-line interface

### DIFF
--- a/console/eeg_encoder.py
+++ b/console/eeg_encoder.py
@@ -1,0 +1,19 @@
+from pipeline.EEGEncoder import EEGEncoder
+import torch
+
+def main():
+    model = EEGEncoder()
+
+    dummy_input = torch.randn(
+        8,      # batch size
+        4,      # EEG channels
+        512     # time samples
+    )
+
+    output = model(dummy_input)
+
+    print("Output shape:", output.shape)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/EEGEncoder.py
+++ b/pipeline/EEGEncoder.py
@@ -1,0 +1,111 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class EEGEncoder(nn.Module):
+    def __init__(self, embedding_dim=256, dropout=0.3):
+        super().__init__()
+
+        # -------------------------
+        # Feature Extraction Blocks
+        # -------------------------
+
+        self.features = nn.Sequential(
+
+            nn.Conv1d(
+                in_channels=4,
+                out_channels=32,
+                kernel_size=7,
+                padding=3
+            ),
+            
+            nn.BatchNorm1d(32),
+            nn.GELU(),
+            nn.MaxPool1d(kernel_size=2),
+
+            nn.Conv1d(
+                in_channels=32,
+                out_channels=64,
+                kernel_size=5,
+                padding=2
+            ),
+            nn.BatchNorm1d(64),
+            nn.GELU(),
+            nn.MaxPool1d(kernel_size=2),
+
+            nn.Conv1d(
+                in_channels=64,
+                out_channels=128,
+                kernel_size=5,
+                padding=2
+            ),
+            nn.BatchNorm1d(128),
+            nn.GELU(),
+            nn.MaxPool1d(kernel_size=2),
+
+            nn.Conv1d(
+                in_channels=128,
+                out_channels=256,
+                kernel_size=3,
+                padding=1
+            ),
+            nn.BatchNorm1d(256),
+            nn.GELU(),
+        )
+
+        # Temporal aggregation
+        self.pool = nn.AdaptiveAvgPool1d(1)
+
+        # -------------------------
+        # Projection Head
+        # -------------------------
+
+        self.projection = nn.Sequential(
+            nn.Linear(256, 256),
+            nn.GELU(),
+            nn.LayerNorm(256),
+            nn.Dropout(dropout),
+            nn.Linear(256, embedding_dim)
+        )
+
+    def forward(self, x):
+        """
+        x shape:
+        [B, 4, 512]
+        """
+
+        x = self.features(x)
+
+        # Shape:
+        # [B, 256, 64]
+
+        x = self.pool(x)
+
+        # Shape:
+        # [B, 256, 1]
+
+        x = x.squeeze(-1)
+
+        # Shape:
+        # [B, 256]
+
+        z = self.projection(x)
+
+        z = F.normalize(z, p=2, dim=1)
+
+        return z
+    
+if __name__ == "__main__":
+
+    model = EEGEncoder()
+
+    dummy_input = torch.randn(
+        8,      # batch size
+        4,      # EEG channels
+        512     # time samples
+    )
+
+    output = model(dummy_input)
+
+    print("Output shape:", output.shape)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
             #! "cmd=module.file:start_function"
             "test_eeg=console.testing:main",
             "trainer=console.trainer:main",
+            "eeg_encoder=console.eeg_encoder:main"
       ]  
     },
     


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new EEG encoder model and expose it via a command-line entry point.

New Features:
- Add an EEGEncoder neural network module for encoding multi-channel EEG signals into normalized embeddings.
- Add a console script that runs the EEGEncoder on dummy input to verify its output shape.

Build:
- Register a new eeg_encoder console entry point in the package setup configuration.