### PR TITLE
Add LatentMapper class and update setup.py for command-line interface

### DIFF
--- a/console/latent_mapper.py
+++ b/console/latent_mapper.py
@@ -1,0 +1,19 @@
+import torch
+
+from pipeline.EEGEncoder import EEGEncoder
+from pipeline.LatentMapper import LatentMapper
+
+def main():
+    x_eeg = torch.randn(8, 4, 512)
+    eeg_encoder = EEGEncoder()
+
+    mapper = LatentMapper()
+
+    z_eeg = eeg_encoder(x_eeg)
+    z_img = mapper(z_eeg)
+
+    print(z_eeg.shape)
+    print(z_img.shape)
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/LatentMapper.py
+++ b/pipeline/LatentMapper.py
@@ -1,0 +1,53 @@
+import torch.nn as nn
+
+class ResidualBlock(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+
+        self.block = nn.Sequential(
+            nn.Linear(dim, dim * 2),
+            nn.GELU(),
+            nn.Linear(dim * 2, dim),
+            nn.LayerNorm(dim)
+        )
+
+    def forward(self, x):
+        return x + self.block(x)
+
+class LatentMapper(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        # -------------------------
+        # Feature Extraction Blocks
+        # -------------------------
+
+        self.input_proj = nn.Sequential(
+            nn.Linear(256, 512),
+            nn.LayerNorm(512),
+            nn.GELU(),
+            nn.Dropout(0.2),
+        )
+
+        self.res_blocks = nn.Sequential(
+            ResidualBlock(512),
+            ResidualBlock(512),
+        )
+
+        self.output_proj = nn.Sequential(
+            nn.Linear(512, 768),
+            nn.LayerNorm(768),
+            nn.Tanh()
+        )
+
+    def forward(self, z_egg):
+        # [B, 256] -> [B, 512]
+        x = self.input_proj(z_egg)
+
+        # residual blocks
+        x = self.res_blocks(x)
+
+        # [B, 512] -> [B, 768]
+        z_img = self.output_proj(x)
+
+        return z_img

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
             #! "cmd=module.file:start_function"
             "test_eeg=console.testing:main",
             "trainer=console.trainer:main",
-            "eeg_encoder=console.eeg_encoder:main"
+            "eeg_encoder=console.eeg_encoder:main",
+            "latent_mapper=console.latent_mapper:main",
       ]  
     },
     


### PR DESCRIPTION
## Summary by Sourcery

Introduce a latent mapping module for transforming EEG encoder outputs into image latents and expose it via a new CLI entry point.

New Features:
- Add a LatentMapper neural network module to map EEG latent vectors to image latent space.
- Provide a latent_mapper console script that runs the EEG encoder and latent mapper and prints the resulting shapes.

Enhancements:
- Register the latent_mapper command in the setup configuration to enable invocation from the command line.