### PR TITLE
Add ImageDecoder class and integrate with setup.py

### DIFF
--- a/console/image_decoder.py
+++ b/console/image_decoder.py
@@ -1,0 +1,37 @@
+import torch
+import matplotlib.pyplot as plt
+
+from pipeline.EEGEncoder import EEGEncoder
+from pipeline.LatentMapper import LatentMapper
+from pipeline.ImageDecoder import ImageDecoder
+
+def show_image(tensor_img):
+    img = tensor_img.detach().cpu()
+
+    img = (img + 1) / 2
+
+    img = img.permute(1, 2, 0)  
+
+    plt.imshow(img)
+    plt.axis("off")
+    plt.show()
+
+def main():
+    x_eeg = torch.randn(8, 4, 512)
+
+    eeg_encoder = EEGEncoder()
+    mapper = LatentMapper()
+    image_decoder = ImageDecoder()
+
+    z_eeg = eeg_encoder(x_eeg)
+    print(z_eeg.shape)
+    z_img = mapper(z_eeg)
+    print(z_img.shape)
+    image = image_decoder(z_img)
+    print(image.shape)
+
+    show_image(image[0])
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/ImageDecoder.py
+++ b/pipeline/ImageDecoder.py
@@ -1,0 +1,85 @@
+import torch
+import torch.nn as nn
+
+class ResBlock(nn.Module):
+    def __init__(self, channels):
+        super().__init__()
+
+        self.block = nn.Sequential(
+            nn.Conv2d(channels, channels, 3, padding=1),
+            nn.BatchNorm2d(channels),
+            nn.GELU(),
+            nn.Conv2d(channels, channels, 3, padding=1),
+            nn.BatchNorm2d(channels),
+        )
+
+        self.act = nn.GELU()
+
+    def forward(self, x):
+        return self.act(x + self.block(x))
+    
+class SelfAttention2D(nn.Module):
+    def __init__(self, channels):
+        super().__init__()
+
+        self.query = nn.Conv2d(channels, channels // 8, 1)
+        self.key   = nn.Conv2d(channels, channels // 8, 1)
+        self.value = nn.Conv2d(channels, channels, 1)
+
+        self.gamma = nn.Parameter(torch.zeros(1))
+
+    def forward(self, x):
+        B, C, H, W = x.shape
+
+        q = self.query(x).view(B, -1, H * W)
+        k = self.key(x).view(B, -1, H * W)
+        v = self.value(x).view(B, -1, H * W)
+
+        attn = torch.softmax(q.transpose(1, 2) @ k, dim=-1)
+
+        out = v @ attn.transpose(1, 2)
+        out = out.view(B, C, H, W)
+
+        return self.gamma * out + x
+
+class ImageDecoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.fc = nn.Sequential(
+            nn.Linear(768, 1024 * 4 * 4),
+            nn.GELU(),
+            nn.LayerNorm(1024 * 4 * 4)
+        )
+
+        self.up1 = self._block(1024, 512)
+        self.up2 = self._block(512, 256)
+        self.up3 = self._block(256, 128)
+        self.up4 = self._block(128, 64)
+
+        self.out = nn.Conv2d(64, 3, kernel_size=3, padding=1)
+
+    def _block(self, in_c, out_c):
+        return nn.Sequential(
+            nn.ConvTranspose2d(in_c, out_c, kernel_size=4, stride=2, padding=1),
+            nn.GELU(),
+            ResBlock(out_c),
+            SelfAttention2D(out_c)
+        )
+
+    def forward(self, z):
+
+        x = self.fc(z)
+
+        x = x.view(x.size(0), 1024, 4, 4)
+
+        x = self.up1(x)
+        x = self.up2(x)
+        x = self.up3(x)
+        x = self.up4(x)
+
+        x = self.out(x)
+
+        x = torch.tanh(x)
+
+        return x

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
             "trainer=console.trainer:main",
             "eeg_encoder=console.eeg_encoder:main",
             "latent_mapper=console.latent_mapper:main",
+            "image_decoder=console.image_decoder:main"
       ]  
     },
     


### PR DESCRIPTION
## Summary by Sourcery

Introduce an image decoding pipeline component and expose it via a new console entry point.

New Features:
- Add an ImageDecoder neural network module that converts latent vectors into RGB images.
- Add a console script that runs the EEG-to-image pipeline using EEGEncoder, LatentMapper, and ImageDecoder and visualizes the output image.

Enhancements:
- Register the new image decoder console entry point in setup.py for easy CLI access.